### PR TITLE
Added search_analyzer property to the mapping annotation

### DIFF
--- a/Classes/Annotations/Mapping.php
+++ b/Classes/Annotations/Mapping.php
@@ -75,6 +75,14 @@ final class Mapping
     public $analyzer;
 
     /**
+     * The analyzer used to analyze the text contents only when searching using a query string.
+     *
+     * @var string
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-analyzer.html
+     */
+	public $search_analyzer;
+    
+    /**
      * The type to use for this
      * Defaults to the property/field type.
      *


### PR DESCRIPTION
This property was missing and made it impossible to configure the elasticsearch mapping for every usecase.

See Elasticsearch Mapping Configuration:
https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-analyzer.html